### PR TITLE
Complete gene coding by symbol in addition to HGNC-ID and Ensembl-ID

### DIFF
--- a/impl/src/main/scala/de/bwhc/mtb/data/entry/impl/HGNCOps.scala
+++ b/impl/src/main/scala/de/bwhc/mtb/data/entry/impl/HGNCOps.scala
@@ -22,6 +22,9 @@ trait HGNCOps
     .orElse(
       coding.hgncId.flatMap(id => hgnc.gene(HGNCId(id.value)))
     )
+    .orElse(
+      coding.symbol.flatMap(symbol => hgnc.geneWithApprovedSymbol(symbol.value))
+    )
     .map(
       gene =>
         Gene.Coding(

--- a/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/HGNCOpsTest.scala
+++ b/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/HGNCOpsTest.scala
@@ -1,0 +1,123 @@
+package de.bwhc.mtb.data.entry.impl
+
+import de.bwhc.mtb.data.entry.dtos.Gene
+import org.scalatest.funspec.AnyFunSpec
+
+class HGNCOpsTest extends AnyFunSpec {
+
+  private lazy val hgncOps = HGNCOps
+
+  describe("Given gene symbol 'TP53'") {
+
+    val coding = Gene.Coding.apply(
+      hgncId = None,
+      ensemblId = None,
+      symbol = Some(Gene.Symbol("TP53")),
+      name = None
+    )
+
+
+    it ("should complete gene coding with HGNC-ID 'HGNC:11998'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.hgncId.contains(Gene.HgncId("HGNC:11998"))
+      ))
+
+    }
+
+
+    it("should complete gene coding with Ensembl-ID 'ENSG00000141510'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.ensemblId.contains(Gene.EnsemblId("ENSG00000141510"))
+      ))
+
+    }
+
+
+    it("should complete gene coding with name 'tumor protein p53'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.name.contains("tumor protein p53"))
+      )
+
+    }
+
+  }
+
+  describe("Given gene HGNC-ID 'HGNC:11998'") {
+
+    val coding = Gene.Coding.apply(
+      hgncId = Some(Gene.HgncId("HGNC:11998")),
+      ensemblId = None,
+      symbol = None,
+      name = None
+    )
+
+
+    it("should complete gene coding with Ensembl-ID 'ENSG00000141510'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.ensemblId.contains(Gene.EnsemblId("ENSG00000141510"))
+      ))
+
+    }
+
+
+    it("should complete gene coding with Symbol 'TP53'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.symbol.contains(Gene.Symbol("TP53"))
+      ))
+
+    }
+
+
+    it("should complete gene coding with name 'tumor protein p53'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.name.contains("tumor protein p53"))
+      )
+
+    }
+
+  }
+
+  describe("Given gene Ensembl-ID 'ENSG00000141510'") {
+
+    val coding = Gene.Coding.apply(
+      hgncId = None,
+      ensemblId = Some(Gene.EnsemblId("ENSG00000141510")),
+      symbol = None,
+      name = None
+    )
+
+    it("should complete gene coding with HGNC-ID 'HGNC:11998'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.hgncId.contains(Gene.HgncId("HGNC:11998"))
+      ))
+
+    }
+
+
+    it("should complete gene coding with Symbol 'TP53'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.symbol.contains(Gene.Symbol("TP53"))
+      ))
+
+    }
+
+
+    it("should complete gene coding with name 'tumor protein p53'") {
+
+      assert(hgncOps.complete(coding).exists(
+        _.name.contains("tumor protein p53"))
+      )
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
This will complete gene coding using given gene symbol. Furthermore, the symbol is now used to add information about the gene, as is already done for the HGNC-ID and Ensembl-ID if these HGNC-ID and/or Ensembl-ID are not present in uploaded data.

In addition, I added some tests for method HGNCOps#complete().