### PR TITLE
Add validation to ensure unregistered codes or displays are not blank

### DIFF
--- a/impl/src/main/scala/de/bwhc/mtb/data/entry/impl/DataValidator.scala
+++ b/impl/src/main/scala/de/bwhc/mtb/data/entry/impl/DataValidator.scala
@@ -341,9 +341,7 @@ extends Logging
         display mustBe defined otherwise (
           Warning(s"Fehlender Medikationsname bei nicht-ATC-Wirkstoff '$code'") at Location("Medication Coding","","Display")
         ) map (c => medication)
-
       }
-
   }
 
  

--- a/impl/src/main/scala/de/bwhc/mtb/data/entry/impl/DataValidator.scala
+++ b/impl/src/main/scala/de/bwhc/mtb/data/entry/impl/DataValidator.scala
@@ -338,9 +338,9 @@ extends Logging
 
       } else {
 
-        display mustBe defined otherwise (
+        display.getOrElse("").isBlank mustNot equal(true) otherwise (
           Warning(s"Fehlender Medikationsname bei nicht-ATC-Wirkstoff '$code'") at Location("Medication Coding","","Display")
-        ) map (c => medication)
+        ) map (_ => medication)
       }
   }
 

--- a/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/ValidatorTests.scala
+++ b/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/ValidatorTests.scala
@@ -182,6 +182,17 @@ class ValidatorTests extends AnyFlatSpec
       validate(medicationCoding).isValid mustBe true
     }
 
+    it must "work as expected for Unregistered code without version and display" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code("ASS"),
+        system = Medication.System.Unregistered,
+        display = None,
+        version = None
+      )
+
+      validate(medicationCoding).isValid mustBe true
+    }
+
     it must "result in errors for ATC code without version" in {
       val medicationCoding = Medication.Coding.apply(
         code = Medication.Code("N02BA01"),
@@ -204,15 +215,37 @@ class ValidatorTests extends AnyFlatSpec
       validate(medicationCoding).isValid mustBe false
     }
 
-    it must "result in errors for empty unregistered medication code" in {
+    it must "result in errors for blank Unregistered medication code and no display" in {
       val medicationCoding = Medication.Coding.apply(
-        code = Medication.Code(""),
+        code = Medication.Code("  "),
+        system = Medication.System.Unregistered,
+        display = None,
+        version = None
+      )
+
+      validate(medicationCoding).isValid mustBe false
+    }
+
+    it must "result in errors for blank Unregistered medication code and blank display" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code("  "),
+        system = Medication.System.Unregistered,
+        display = Some("  "),
+        version = None
+      )
+
+      validate(medicationCoding).isValid mustBe false
+    }
+
+    it must "work as expected for blank Unregistered medication code but non blank display" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code("  "),
         system = Medication.System.Unregistered,
         display = Some("Whatever"),
         version = None
       )
 
-      validate(medicationCoding).isValid mustBe false
+      validate(medicationCoding).isValid mustBe true
     }
 
 }

--- a/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/ValidatorTests.scala
+++ b/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/ValidatorTests.scala
@@ -182,7 +182,7 @@ class ValidatorTests extends AnyFlatSpec
       validate(medicationCoding).isValid mustBe true
     }
 
-    it must "work as expected for Unregistered code without version and display" in {
+    it must "result in error for Unregistered code without version and display" in {
       val medicationCoding = Medication.Coding.apply(
         code = Medication.Code("ASS"),
         system = Medication.System.Unregistered,
@@ -190,7 +190,7 @@ class ValidatorTests extends AnyFlatSpec
         version = None
       )
 
-      validate(medicationCoding).isValid mustBe true
+      validate(medicationCoding).isValid mustBe false
     }
 
     it must "result in errors for ATC code without version" in {

--- a/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/ValidatorTests.scala
+++ b/impl/src/test/scala/de/bwhc/mtb/data/entry/impl/ValidatorTests.scala
@@ -147,8 +147,72 @@ class ValidatorTests extends AnyFlatSpec
 
   }
 
+  behavior of "Medication validation"
 
+    it must "work as expected for valid ATC code" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code("N02BA01"),
+        system = Medication.System.ATC,
+        display = Some("Acetylsalicylsäure"),
+        version = Some("2023")
+      )
 
+      validate(medicationCoding).isValid mustBe true
+    }
 
+    it must "result in error if supplying ATC group code" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code("N02"),
+        system = Medication.System.ATC,
+        display = Some("Analgesics"),
+        version = Some("2023")
+      )
+
+      validationIssuesOf(medicationCoding) must contain (Error)
+    }
+
+    it must "work as expected for Unregistered code without version" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code("ASS"),
+        system = Medication.System.Unregistered,
+        display = Some("Acetylsalicylsäure"),
+        version = None
+      )
+
+      validate(medicationCoding).isValid mustBe true
+    }
+
+    it must "result in errors for ATC code without version" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code("N02BA01"),
+        system = Medication.System.ATC,
+        display = Some("Acetylsalicylsäure"),
+        version = None
+      )
+
+      validationIssuesOf(medicationCoding) must contain (Error)
+    }
+
+    it must "result in errors for empty atc medication code" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code(""),
+        system = Medication.System.ATC,
+        display = Some("Whatever"),
+        version = None
+      )
+
+      validate(medicationCoding).isValid mustBe false
+    }
+
+    it must "result in errors for empty unregistered medication code" in {
+      val medicationCoding = Medication.Coding.apply(
+        code = Medication.Code(""),
+        system = Medication.System.Unregistered,
+        display = Some("Whatever"),
+        version = None
+      )
+
+      validate(medicationCoding).isValid mustBe false
+    }
 
 }


### PR DESCRIPTION
With this change, by-passing validation for unregistered system will replaced with checked for blank codes and displays.

In addition to that, some tests for medication code validation has been added